### PR TITLE
Fixed vitis-ai-user@desktop:/workspace/GPU inference$ python3 gpu_inf…

### DIFF
--- a/Quantizing-Compiling-YOLOv3-Pytorch-with-DPU-Inference/GPU inference/gpu_inference.py
+++ b/Quantizing-Compiling-YOLOv3-Pytorch-with-DPU-Inference/GPU inference/gpu_inference.py
@@ -81,9 +81,9 @@ with torch.no_grad():
 
 # Convert tensor to numpy
 output = []
-output.append(out[0].numpy())
-output.append(out[1].numpy())
-output.append(out[2].numpy())
+output.append(out[0].cpu().numpy())
+output.append(out[1].cpu().numpy())
+output.append(out[2].cpu().numpy())
 # print(len(output))
 # print(output[0].shape) # (1, 255, 13, 13) -> numpy
 


### PR DESCRIPTION
Fix for Issue#7: https://github.com/LogicTronix/Vitis-AI-Reference-Tutorials/issues/7